### PR TITLE
Support iproute2 bpf_map_def layout

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -48,7 +48,7 @@ unsafe_impl_pod!(i8, u8, i16, u16, i32, u32, i64, u64);
 
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug, Default)]
+#[derive(Copy, Clone, Debug, Default, PartialEq)]
 pub(crate) struct bpf_map_def {
     // minimum features required by old BPF programs
     pub(crate) map_type: u32,

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -57,8 +57,8 @@ pub(crate) struct bpf_map_def {
     pub(crate) max_entries: u32,
     pub(crate) map_flags: u32,
     // optional features
-    pub(crate) id: u32, // id
-    pub(crate) pinning: u32,    // pinning
+    pub(crate) id: u32,
+    pub(crate) pinning: u32,
 }
 
 /// The main entry point into the library, used to work with eBPF programs and maps.

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -48,7 +48,7 @@ unsafe_impl_pod!(i8, u8, i16, u16, i32, u32, i64, u64);
 
 #[allow(non_camel_case_types)]
 #[repr(C)]
-#[derive(Copy, Clone, Debug)]
+#[derive(Copy, Clone, Debug, Default)]
 pub(crate) struct bpf_map_def {
     // minimum features required by old BPF programs
     pub(crate) map_type: u32,
@@ -57,34 +57,8 @@ pub(crate) struct bpf_map_def {
     pub(crate) max_entries: u32,
     pub(crate) map_flags: u32,
     // optional features
-    pub(crate) inner_map_fd: u32, // id
-    pub(crate) numa_node: u32,    // pinning
-    pub(crate) map_name: [u8; BPF_OBJ_NAME_LEN],
-    pub(crate) map_ifindex: u32,
-    pub(crate) btf_id: u32,
-    pub(crate) btf_key_type_id: u32,
-    pub(crate) btf_value_type_id: u32,
-    pub(crate) btf_vmlinux_value_type_id: u32,
-}
-
-impl Default for bpf_map_def {
-    fn default() -> Self {
-        Self {
-            map_type: 0,
-            key_size: 0,
-            value_size: 0,
-            max_entries: 0,
-            map_flags: 0,
-            inner_map_fd: 0,
-            numa_node: 0,
-            map_name: [0u8; BPF_OBJ_NAME_LEN],
-            map_ifindex: 0,
-            btf_id: 0,
-            btf_key_type_id: 0,
-            btf_value_type_id: 0,
-            btf_vmlinux_value_type_id: 0
-        }
-    }
+    pub(crate) id: u32, // id
+    pub(crate) pinning: u32,    // pinning
 }
 
 /// The main entry point into the library, used to work with eBPF programs and maps.

--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -50,13 +50,41 @@ unsafe_impl_pod!(i8, u8, i16, u16, i32, u32, i64, u64);
 #[repr(C)]
 #[derive(Copy, Clone, Debug)]
 pub(crate) struct bpf_map_def {
+    // minimum features required by old BPF programs
     pub(crate) map_type: u32,
     pub(crate) key_size: u32,
     pub(crate) value_size: u32,
     pub(crate) max_entries: u32,
     pub(crate) map_flags: u32,
-    pub(crate) id: u32,
-    pub(crate) pinning: u32,
+    // optional features
+    pub(crate) inner_map_fd: u32, // id
+    pub(crate) numa_node: u32,    // pinning
+    pub(crate) map_name: [u8; BPF_OBJ_NAME_LEN],
+    pub(crate) map_ifindex: u32,
+    pub(crate) btf_id: u32,
+    pub(crate) btf_key_type_id: u32,
+    pub(crate) btf_value_type_id: u32,
+    pub(crate) btf_vmlinux_value_type_id: u32,
+}
+
+impl Default for bpf_map_def {
+    fn default() -> Self {
+        Self {
+            map_type: 0,
+            key_size: 0,
+            value_size: 0,
+            max_entries: 0,
+            map_flags: 0,
+            inner_map_fd: 0,
+            numa_node: 0,
+            map_name: [0u8; BPF_OBJ_NAME_LEN],
+            map_ifindex: 0,
+            btf_id: 0,
+            btf_key_type_id: 0,
+            btf_value_type_id: 0,
+            btf_vmlinux_value_type_id: 0
+        }
+    }
 }
 
 /// The main entry point into the library, used to work with eBPF programs and maps.

--- a/aya/src/maps/hash_map/hash_map.rs
+++ b/aya/src/maps/hash_map/hash_map.rs
@@ -162,9 +162,7 @@ mod tests {
                 key_size: 4,
                 value_size: 4,
                 max_entries: 1024,
-                map_flags: 0,
-                id: 0,
-                pinning: 0,
+                ..Default::default()
             },
             section_index: 0,
             data: Vec::new(),
@@ -215,9 +213,7 @@ mod tests {
                     key_size: 4,
                     value_size: 4,
                     max_entries: 1024,
-                    map_flags: 0,
-                    id: 0,
-                    pinning: 0,
+                    ..Default::default()
                 },
                 section_index: 0,
                 data: Vec::new(),
@@ -273,9 +269,7 @@ mod tests {
                     key_size: 4,
                     value_size: 4,
                     max_entries: 1024,
-                    map_flags: 0,
-                    id: 0,
-                    pinning: 0,
+                    ..Default::default()
                 },
                 section_index: 0,
                 data: Vec::new(),

--- a/aya/src/maps/mod.rs
+++ b/aya/src/maps/mod.rs
@@ -426,9 +426,7 @@ mod tests {
                 key_size: 4,
                 value_size: 4,
                 max_entries: 1024,
-                map_flags: 0,
-                id: 0,
-                pinning: 0,
+                ..Default::default()
             },
             section_index: 0,
             data: Vec::new(),

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -521,7 +521,9 @@ fn parse_map_def(name: &str, data: &[u8]) -> Result<bpf_map_def, ParseError> {
 
     unsafe {
         // std::ptr::copy is const, we can't use it because data.len() isn't known at
-        // compile time
+        // compile time, this is only safe because we've asserted that data.len()
+        // must be <= mem::size_of::<bpf_map_def>(), if you change that check, then
+        // you must change this copy
         let mut p = data.as_ptr();
         let mut q = &mut map_def as *mut bpf_map_def as *mut u8;
         for _ in 0..=data.len() {

--- a/aya/src/obj/mod.rs
+++ b/aya/src/obj/mod.rs
@@ -516,7 +516,7 @@ fn parse_map_def(name: &str, data: &[u8]) -> Result<bpf_map_def, ParseError> {
     }
 
     if data.len() <  mem::size_of::<bpf_map_def>() {
-        let mut map_def = bpf_map_def { ..Default::default() };
+        let mut map_def = bpf_map_def::default();
         unsafe {
             ptr::copy(data.as_ptr() as *const bpf_map_def, &mut map_def as *mut bpf_map_def, 1);
             // id and pinning will be garbage data


### PR DESCRIPTION
Addresses #10 

Please note, while this passes tests I haven't had a chance to actually try it with an older/new map definitions. If someone has an old program lying around, please test it before merging.

It also breaks the `id` and `pinning` fields, replacing them with the members found [here](https://elixir.bootlin.com/linux/v5.12.12/source/include/uapi/linux/bpf.h#L491). 