### PR TITLE
bpf: add support for STACK_TRACE map

### DIFF
--- a/bpf/aya-bpf/src/maps/mod.rs
+++ b/bpf/aya-bpf/src/maps/mod.rs
@@ -4,6 +4,7 @@ pub mod perf_map;
 pub mod queue;
 pub mod sock_hash;
 pub mod sock_map;
+pub mod stack_trace;
 
 pub use array::Array;
 pub use hash_map::HashMap;
@@ -11,3 +12,4 @@ pub use perf_map::PerfMap;
 pub use queue::Queue;
 pub use sock_hash::SockHash;
 pub use sock_map::SockMap;
+pub use stack_trace::StackTrace;

--- a/bpf/aya-bpf/src/maps/stack_trace.rs
+++ b/bpf/aya-bpf/src/maps/stack_trace.rs
@@ -1,0 +1,43 @@
+use core::mem;
+
+use crate::{
+    bindings::{bpf_map_def, bpf_map_type::BPF_MAP_TYPE_STACK_TRACE},
+    helpers::{bpf_get_stackid},
+    BpfContext,
+};
+
+#[repr(transparent)]
+pub struct StackTrace {
+	def: bpf_map_def,
+}
+
+const PERF_MAX_STACK_DEPTH: u32 = 127;
+
+impl StackTrace {
+	pub const fn with_max_entries(max_entries: u32, flags: u32) -> StackTrace {
+		StackTrace {
+			def: bpf_map_def {
+				type_: BPF_MAP_TYPE_STACK_TRACE,
+				key_size: mem::size_of::<u32>() as u32,
+				value_size: mem::size_of::<u64>() as u32 * PERF_MAX_STACK_DEPTH,
+				max_entries,
+				map_flags: flags,
+				id: 0,
+				pinning: 0,
+			},
+		}
+	}
+
+	pub unsafe fn get_stackid<C: BpfContext>(&mut self, ctx: &C, flags: u64) -> Result<u32, i64> {
+		let ret = bpf_get_stackid(
+			ctx.as_ptr(),
+			&mut self.def as *mut _ as *mut _,
+			flags,
+		);
+		if ret < 0 {
+			Err(ret)
+		} else {
+			Ok(ret as u32)
+		}
+	}
+}


### PR DESCRIPTION
This path support initial support for BPF_MAP_TYPE_STACK_TRACE.

Signed-off-by: Tw <wei.tan@intel.com>