### PR TITLE
bpf: fix a minor bug due to stackid allocation

### DIFF
--- a/bpf/aya-bpf/src/maps/stack_trace.rs
+++ b/bpf/aya-bpf/src/maps/stack_trace.rs
@@ -28,7 +28,7 @@ impl StackTrace {
 		}
 	}
 
-	pub unsafe fn get_stackid<C: BpfContext>(&mut self, ctx: &C, flags: u64) -> Result<u32, i64> {
+	pub unsafe fn get_stackid<C: BpfContext>(&mut self, ctx: &C, flags: u64) -> Result<i64, i64> {
 		let ret = bpf_get_stackid(
 			ctx.as_ptr(),
 			&mut self.def as *mut _ as *mut _,
@@ -37,7 +37,7 @@ impl StackTrace {
 		if ret < 0 {
 			Err(ret)
 		} else {
-			Ok(ret as u32)
+			Ok(ret)
 		}
 	}
 }


### PR DESCRIPTION
The type casting introduces an allocation, this will cause compiling failure when linking final bpf target.
So remove this casting to fix this issue.

BTW, the following is the failure I met:

```
= note: 07:24:12 [ERROR] fatal error: "unable to allocate function return #1"
          PLEASE submit a bug report to https://bugs.llvm.org/ and include the crash backtrace.
          Stack dump:
          0.    Running pass 'Function Pass Manager' on module 'trace_bpf-001a275b17e9eb12'.
          1.    Running pass 'BPF DAG->DAG Pattern Instruction Selection' on function '@_ZN7aya_bpf4maps11stack_trace10StackTrace11get_stackid17h32b649bc3780c0aaE'
```

Signed-off-by: Tw <wei.tan@intel.com>