### PR TITLE
fix: pass BTF object by reference in order to allow multiple eBPF programs to share it and save memory (closes #30).

### DIFF
--- a/aya/src/bpf.rs
+++ b/aya/src/bpf.rs
@@ -90,7 +90,7 @@ impl Bpf {
                 path: path.to_owned(),
                 error,
             })?,
-            Btf::from_sys_fs().ok(),
+            Btf::from_sys_fs().ok().as_ref(),
         )
     }
 
@@ -98,7 +98,8 @@ impl Bpf {
     ///
     /// Parses the object code contained in `data` and initializes the [maps](crate::maps) defined
     /// in it. If `target_btf` is not `None` and `data` includes BTF debug info, [BTF](Btf) relocations
-    /// are applied as well.
+    /// are applied as well. In order to allow sharing of a single [BTF](Btf) object among multiple
+    /// eBPF programs, `target_btf` is passed by reference.
     ///
     /// # Examples
     ///
@@ -108,10 +109,10 @@ impl Bpf {
     ///
     /// let data = fs::read("file.o").unwrap();
     /// // load the BTF data from /sys/kernel/btf/vmlinux
-    /// let bpf = Bpf::load(&data, Some(Btf::from_sys_fs()?));
+    /// let bpf = Bpf::load(&data, Btf::from_sys_fs().ok().as_ref());
     /// # Ok::<(), aya::BpfError>(())
     /// ```
-    pub fn load(data: &[u8], target_btf: Option<Btf>) -> Result<Bpf, BpfError> {
+    pub fn load(data: &[u8], target_btf: Option<&Btf>) -> Result<Bpf, BpfError> {
         let mut obj = Object::parse(data)?;
 
         if let Some(btf) = target_btf {

--- a/aya/src/obj/btf/relocation.rs
+++ b/aya/src/obj/btf/relocation.rs
@@ -151,7 +151,7 @@ impl Relocation {
 }
 
 impl Object {
-    pub fn relocate_btf(&mut self, target_btf: Btf) -> Result<(), BpfError> {
+    pub fn relocate_btf(&mut self, target_btf: &Btf) -> Result<(), BpfError> {
         let (local_btf, btf_ext) = match (&self.btf, &self.btf_ext) {
             (Some(btf), Some(btf_ext)) => (btf, btf_ext),
             _ => return Ok(()),
@@ -174,13 +174,8 @@ impl Object {
                     function: section_name.to_owned(),
                     error: Box::new(RelocationError::ProgramNotFound),
                 })?;
-            match relocate_btf_program(
-                program,
-                relos,
-                local_btf,
-                &target_btf,
-                &mut candidates_cache,
-            ) {
+            match relocate_btf_program(program, relos, local_btf, target_btf, &mut candidates_cache)
+            {
                 Ok(_) => {}
                 Err(ErrorWrapper::BtfError(e)) => return Err(e.into()),
                 Err(ErrorWrapper::RelocationError(error)) => {


### PR DESCRIPTION
As per title, this PR changtes `Bpf::load` to use `Option<&Btf>` instead of `Option<Btf>` so that a single instance of Btf information can be shared among multiple programs, thus decreasing overall memory usage.