### PR TITLE
Fix rustup command in the docs.

### DIFF
--- a/docs/src/start/development.md
+++ b/docs/src/start/development.md
@@ -7,7 +7,7 @@ This is easily achieved with [`rustup`]:
 
 ```console
 rustup install stable
-rustup install nightly --component rust-src
+rustup toolchain install nightly --component rust-src
 ```
 
 Once you have the Rust tool-chains installed, you must also install the `bpf-linker` - for linking our eBPF program - and `cargo-generate` - for generating the project skeleton.


### PR DESCRIPTION
`rustup install nightly --component rust-src`

gives:

```
error: Found argument '--component' which wasn't expected, or isn't valid in this context

USAGE:
    rustup install [FLAGS] [OPTIONS] <toolchain>...

For more information try --help
```

The correct command seems to be `rustup toolchain install nightly --component rust-src`.